### PR TITLE
improve release for easier installation with koikatsu

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,10 @@ jobs:
       run: msbuild KK_ButtPlugin.sln /p:Configuration=Release /p:DeployOnBuild=true /p:PublishProfile=FolderProfile
     
     - name: Zip artifacts
-      run: powershell Compress-Archive -Path bin/* -DestinationPath ButtPlugin.zip
+      run: |-
+        powershell New-Item -Path BepInEx/plugins/KK_ButtPlugin -ItemType Directory;
+        powershell Copy-Item -Path bin/* -Destination BepInEx/plugins/KK_ButtPlugin;
+        powershell Compress-Archive -Path BepInEx -DestinationPath ButtPlugin.zip
 
     - name: Release
       uses: "marvinpinto/action-automatic-releases@latest"


### PR DESCRIPTION
This adjusts the output zip file of manual releases to match the common distribution format of BepInEx plugins, where you can simply overlay the zip contents against the root directory of koikatsu and onto your existing BepInEx install.