### PR TITLE
Add device list to BepInEx config UI

### DIFF
--- a/KK_ButtPlugin/ButtPlugin.cs
+++ b/KK_ButtPlugin/ButtPlugin.cs
@@ -2,6 +2,7 @@
 using BepInEx.Bootstrap;
 using BepInEx.Configuration;
 using BepInEx.Logging;
+using UnityEngine;
 
 namespace KK_ButtPlugin
 {
@@ -41,9 +42,66 @@ namespace KK_ButtPlugin
                 key: "Enable Vibrators",
                 defaultValue: true,
                 "Maps control speed to vibrations");
+            Config.Bind(
+                section: "Device List",
+                key: "Connected",
+                defaultValue: "",
+                new ConfigDescription(
+                    "",
+                    null,
+                    new ConfigurationManagerAttributes { 
+                        CustomDrawer = DeviceListDrawer,
+                        HideSettingName = true,
+                        HideDefaultButton = true,
+                        Order = 999  // show device list at the end
+                    }
+                )
+            );
             Logger = base.Logger;
             Chainloader.ManagerObject.AddComponent<ButtplugController>();
             Hooks.InstallHooks();
+        }
+
+        static void DeviceListDrawer(ConfigEntryBase entry)
+        {
+            var controller = Chainloader.ManagerObject.GetComponent<ButtplugController>();
+            
+            GUILayout.BeginVertical(GUILayout.ExpandWidth(true));
+                GUILayout.BeginHorizontal();
+                    GUILayout.FlexibleSpace();
+                    if (GUILayout.Button("Connect", GUILayout.Width(150)))
+                    {
+                        controller.Connect();
+                    }
+                    if (controller.IsConnected)
+                    {
+                        if (GUILayout.Button("Scan", GUILayout.Width(150)))
+                        {
+                            controller.Scan();
+                        }
+                    }
+                    GUILayout.FlexibleSpace();
+                GUILayout.EndHorizontal();
+
+                GUILayout.Space(12);
+
+                // table header
+                GUILayout.BeginHorizontal(GUILayout.ExpandWidth(true));
+                    GUILayout.Label("Device Name", GUILayout.ExpandWidth(true));
+                    GUILayout.Label("Stroker", GUILayout.Width(100));
+                    GUILayout.Label("Vibrators", GUILayout.Width(100));
+                GUILayout.EndHorizontal();
+            
+                foreach (var device in controller.Devices)
+                {
+                    GUILayout.BeginHorizontal(GUILayout.ExpandWidth(true));
+                        GUILayout.Label(device.DeviceName, GUILayout.ExpandWidth(true));
+                        GUILayout.Toggle(device.IsStroker, "", GUILayout.Width(100));
+                        GUILayout.Toggle(device.IsVibrator, "", GUILayout.Width(100));
+                    GUILayout.EndHorizontal();
+                }
+                
+            GUILayout.EndVertical();
         }
     }
 }

--- a/KK_ButtPlugin/ButtplugController.cs
+++ b/KK_ButtPlugin/ButtplugController.cs
@@ -84,7 +84,17 @@ namespace KK_ButtPlugin
 
         private readonly ButtplugWsClient client = new ButtplugWsClient();
         private HFlag flags;
+
+        public List<Device> Devices 
+        {
+            get { return client.Devices; }
+        }
         
+        public bool IsConnected
+        {
+            get { return client.IsConnected; }
+        }
+
         public void OnStartH(HFlag flags)
         {
             this.flags = flags;
@@ -94,7 +104,28 @@ namespace KK_ButtPlugin
 
         void OnDestroy()
         {
+            StopAllCoroutines();
             client.Close();
+        }
+
+        public void Connect()
+        {
+            client.Close(); // close previous connection just in case
+            client.Open();
+
+            Scan();
+        }
+
+        public void Scan()
+        {
+            StartCoroutine("ScanDevices");
+        }
+
+        IEnumerator ScanDevices()
+        {
+            client.StartScan();
+            yield return new WaitForSeconds(15.0f);
+            client.StopScan();
         }
 
         IEnumerator UntilReady()
@@ -133,6 +164,9 @@ namespace KK_ButtPlugin
                 }
                 yield return new WaitForSeconds(.01f);
             }
+            // turn off vibration since there's nothing to animate against
+            // this state can happen if H is ended while the animation is not in Idle
+            DoVibrate(0.0f);
         }
 
         IEnumerator RunStroke()

--- a/KK_ButtPlugin/ConfigurationManagerAttributes.cs
+++ b/KK_ButtPlugin/ConfigurationManagerAttributes.cs
@@ -1,0 +1,103 @@
+﻿/// <summary>
+/// Class that specifies how a setting should be displayed inside the ConfigurationManager settings window.
+/// 
+/// Usage:
+/// This class template has to be copied inside the plugin's project and referenced by its code directly.
+/// make a new instance, assign any fields that you want to override, and pass it as a tag for your setting.
+/// 
+/// If a field is null (default), it will be ignored and won't change how the setting is displayed.
+/// If a field is non-null (you assigned a value to it), it will override default behavior.
+/// </summary>
+/// 
+/// <example> 
+/// Here's an example of overriding order of settings and marking one of the settings as advanced:
+/// <code>
+/// // Override IsAdvanced and Order
+/// Config.AddSetting("X", "1", 1, new ConfigDescription("", null, new ConfigurationManagerAttributes { IsAdvanced = true, Order = 3 }));
+/// // Override only Order, IsAdvanced stays as the default value assigned by ConfigManager
+/// Config.AddSetting("X", "2", 2, new ConfigDescription("", null, new ConfigurationManagerAttributes { Order = 1 }));
+/// Config.AddSetting("X", "3", 3, new ConfigDescription("", null, new ConfigurationManagerAttributes { Order = 2 }));
+/// </code>
+/// </example>
+/// 
+/// <remarks> 
+/// You can read more and see examples in the readme at https://github.com/BepInEx/BepInEx.ConfigurationManager
+/// You can optionally remove fields that you won't use from this class, it's the same as leaving them null.
+/// </remarks>
+#pragma warning disable 0169, 0414, 0649
+internal sealed class ConfigurationManagerAttributes
+{
+    /// <summary>
+    /// Should the setting be shown as a percentage (only use with value range settings).
+    /// </summary>
+    public bool? ShowRangeAsPercent;
+
+    /// <summary>
+    /// Custom setting editor (OnGUI code that replaces the default editor provided by ConfigurationManager).
+    /// See below for a deeper explanation. Using a custom drawer will cause many of the other fields to do nothing.
+    /// </summary>
+    public System.Action<BepInEx.Configuration.ConfigEntryBase> CustomDrawer;
+
+    /// <summary>
+    /// Show this setting in the settings screen at all? If false, don't show.
+    /// </summary>
+    public bool? Browsable;
+
+    /// <summary>
+    /// Category the setting is under. Null to be directly under the plugin.
+    /// </summary>
+    public string Category;
+
+    /// <summary>
+    /// If set, a "Default" button will be shown next to the setting to allow resetting to default.
+    /// </summary>
+    public object DefaultValue;
+
+    /// <summary>
+    /// Force the "Reset" button to not be displayed, even if a valid DefaultValue is available. 
+    /// </summary>
+    public bool? HideDefaultButton;
+
+    /// <summary>
+    /// Force the setting name to not be displayed. Should only be used with a <see cref="CustomDrawer"/> to get more space.
+    /// Can be used together with <see cref="HideDefaultButton"/> to gain even more space.
+    /// </summary>
+    public bool? HideSettingName;
+
+    /// <summary>
+    /// Optional description shown when hovering over the setting.
+    /// Not recommended, provide the description when creating the setting instead.
+    /// </summary>
+    public string Description;
+
+    /// <summary>
+    /// Name of the setting.
+    /// </summary>
+    public string DispName;
+
+    /// <summary>
+    /// Order of the setting on the settings list relative to other settings in a category.
+    /// 0 by default, higher number is higher on the list.
+    /// </summary>
+    public int? Order;
+
+    /// <summary>
+    /// Only show the value, don't allow editing it.
+    /// </summary>
+    public bool? ReadOnly;
+
+    /// <summary>
+    /// If true, don't show the setting by default. User has to turn on showing advanced settings or search for it.
+    /// </summary>
+    public bool? IsAdvanced;
+
+    /// <summary>
+    /// Custom converter from setting type to string for the built-in editor textboxes.
+    /// </summary>
+    public System.Func<object, string> ObjToStr;
+
+    /// <summary>
+    /// Custom converter from string to setting type for the built-in editor textboxes.
+    /// </summary>
+    public System.Func<string, object> StrToObj;
+}


### PR DESCRIPTION
This creates a new UI section for listing connected devices.  Also adds convenience buttons for reconnecting to a server after Koikatsu has started, and for scanning devices.  This is helpful for cases where you close a buttplug server in the middle of gameplay, so now you can restart it, reconnect devices, and continue from where you left off.

![image](https://user-images.githubusercontent.com/316728/125835681-5d3a4468-098b-4d39-ac97-0be9f533cfcb.png)
