### PR TITLE
Add Animation Synced Vibrations

### DIFF
--- a/KK_ButtPlugin/ButtPlugin.cs
+++ b/KK_ButtPlugin/ButtPlugin.cs
@@ -19,6 +19,8 @@ namespace KK_ButtPlugin
         public static ConfigEntry<int> MaxStrokesPerMinute { get; private set; }
         public static ConfigEntry<int> LatencyMs { get; private set; }
         public static ConfigEntry<bool> EnableVibrate { get; private set; }
+        public static ConfigEntry<bool> SyncVibrationWithAnimation { get; private set; }
+        public static ConfigEntry<int> VibrationFrequency { get; private set; }
 
         private void Start()
         {
@@ -28,21 +30,35 @@ namespace KK_ButtPlugin
                 defaultValue: "ws://localhost:12345/",
                 "The Buttplug server address (requires game restart).");
             MaxStrokesPerMinute = Config.Bind(
-                section: "Device",
+                section: "Stroker Settings",
                 key: "Maximum strokes per minute",
                 defaultValue: 140,
                 "The top speed possible on your stroker at 70% stroke length.");
             LatencyMs = Config.Bind(
-                section: "Device",
+                section: "Stroker Settings",
                 key: "Latency (ms)",
                 defaultValue: 0,
                 "The difference in latency between your stroker and your display. \n" +
                 "Negative if your stroker has lower latency.");
             EnableVibrate = Config.Bind(
-                section: "Device",
+                section: "Vibration Settings",
                 key: "Enable Vibrators",
                 defaultValue: true,
-                "Maps control speed to vibrations");
+                "Maps control speed to vibrations"
+            );
+            SyncVibrationWithAnimation = Config.Bind(
+                section: "Vibration Settings",
+                key: "Vibration With Animation",
+                defaultValue: false,
+                "Maps vibrations to a wave pattern in sync with animations.\n" +
+                "Timings are approximations based on animation length and not precise location of stimulation."
+            );
+            VibrationFrequency = Config.Bind(
+                section: "Vibration Settings",
+                key: "Update Frequency (per second)",
+                defaultValue: 30,
+                "Average times per second we update the vibration state."
+            );
             Config.Bind(
                 section: "Device List",
                 key: "Connected",
@@ -103,7 +119,7 @@ namespace KK_ButtPlugin
                         GUILayout.Toggle(device.IsStroker, "", GUILayout.Width(100));
                         GUILayout.Toggle(device.IsVibrator, "", GUILayout.Width(100));
                         var options = new string[] { "First girl", "Second girl", "Off" };
-                        device.GirlIndex = GUILayout.SelectionGrid(device.GirlIndex, options, 1);
+                        device.GirlIndex = GUILayout.SelectionGrid(device.GirlIndex, options, 1, GUILayout.Width(100));
                     GUILayout.EndHorizontal();
                 }
                 

--- a/KK_ButtPlugin/ButtPlugin.cs
+++ b/KK_ButtPlugin/ButtPlugin.cs
@@ -20,7 +20,7 @@ namespace KK_ButtPlugin
         public static ConfigEntry<int> LatencyMs { get; private set; }
         public static ConfigEntry<bool> EnableVibrate { get; private set; }
         public static ConfigEntry<bool> SyncVibrationWithAnimation { get; private set; }
-        public static ConfigEntry<int> VibrationFrequency { get; private set; }
+        public static ConfigEntry<int> VibrationUpdateFrequency { get; private set; }
 
         private void Start()
         {
@@ -53,7 +53,7 @@ namespace KK_ButtPlugin
                 "Maps vibrations to a wave pattern in sync with animations.\n" +
                 "Timings are approximations based on animation length and not precise location of stimulation."
             );
-            VibrationFrequency = Config.Bind(
+            VibrationUpdateFrequency = Config.Bind(
                 section: "Vibration Settings",
                 key: "Update Frequency (per second)",
                 defaultValue: 30,
@@ -76,26 +76,28 @@ namespace KK_ButtPlugin
             );
             Logger = base.Logger;
             Info = base.Info;
-            Chainloader.ManagerObject.AddComponent<ButtplugController>();
+            Chainloader.ManagerObject.AddComponent<ButtplugWsClient>();
+            Chainloader.ManagerObject.AddComponent<ButtplugStrokerController>();
+            Chainloader.ManagerObject.AddComponent<ButtplugVibrationController>();
             Hooks.InstallHooks();
         }
 
         static void DeviceListDrawer(ConfigEntryBase entry)
         {
-            var controller = Chainloader.ManagerObject.GetComponent<ButtplugController>();
+            var serverController = Chainloader.ManagerObject.GetComponent<ButtplugWsClient>();
             
             GUILayout.BeginVertical(GUILayout.ExpandWidth(true));
                 GUILayout.BeginHorizontal();
                     GUILayout.FlexibleSpace();
                     if (GUILayout.Button("Connect", GUILayout.Width(150)))
                     {
-                        controller.Connect();
+                        serverController.Connect();
                     }
-                    if (controller.IsConnected)
+                    if (serverController.IsConnected)
                     {
                         if (GUILayout.Button("Scan", GUILayout.Width(150)))
                         {
-                            controller.Scan();
+                            serverController.Scan();
                         }
                     }
                     GUILayout.FlexibleSpace();
@@ -111,7 +113,7 @@ namespace KK_ButtPlugin
                     GUILayout.Label("Threesome Role", GUILayout.Width(100));
                 GUILayout.EndHorizontal();
             
-                foreach (var device in controller.Devices)
+                foreach (var device in serverController.Devices)
                 {
                     GUILayout.Space(10);
                     GUILayout.BeginHorizontal(GUILayout.ExpandWidth(true));

--- a/KK_ButtPlugin/ButtplugController.cs
+++ b/KK_ButtPlugin/ButtplugController.cs
@@ -1,4 +1,4 @@
-﻿using LitJson;
+using LitJson;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -14,25 +14,64 @@ namespace KK_ButtPlugin
         {
             HFlag.EMode.houshi, HFlag.EMode.sonyu, HFlag.EMode.houshi3P, HFlag.EMode.sonyu3P
         };
+
+        private static readonly List<string> orgasmAnimations = new List<string>
+        {
+            "OLoop", "A_OLoop",
+
+            // ejaculation
+            "OUT_START", "OUT_LOOP", "IN_START", "IN_LOOP",
+            "M_OUT_Start", "M_OUT_Loop", "M_IN_Start", "M_IN_Loop",
+            "WS_IN_Start", "WS_IN_Loop", "SS_IN_Start", "SS_IN_Loop",
+            "A_WS_IN_Start", "A_WS_IN_Loop", "A_SS_IN_Start", "A_SS_IN_Loop",
+
+            // insertion excitement
+            "Pull", "A_Pull", "Insert", "A_Insert"
+        };
+
         private static readonly List<string> supportedAnimations = new List<string>
         {
-            "WLoop", "SLoop", "OLoop"
+            "WLoop", "SLoop",
+            // masturbation
+            "MLoop", 
+            // anal
+            "A_WLoop", "A_SLoop", "A_OLoop",
+
+            // orgasm
+            "OLoop", "A_OLoop",
+            "OUT_START", "OUT_LOOP", "IN_START", "IN_LOOP",
+            "M_OUT_Start", "M_OUT_Loop", "M_IN_Start", "M_IN_Loop",
+            "WS_IN_Start", "WS_IN_Loop", "SS_IN_Start", "SS_IN_Loop",
+            "A_WS_IN_Start", "A_WS_IN_Loop", "A_SS_IN_Start", "A_SS_IN_Loop",
+            
+            // insertion
+            "Pull", "A_Pull", "Insert", "A_Insert"
         };
+
+        
+        
+
         // animation -> fractional part of normalized time at start of up-stroke
         private Dictionary<string, float> animPhases;
 
         private readonly ButtplugWsClient client = new ButtplugWsClient();
         private HFlag flags;
 
-        public List<Device> Devices 
+        public List<Device> Devices
         {
             get { return client.Devices; }
         }
-        
+
         public bool IsConnected
         {
             get { return client.IsConnected; }
         }
+
+        public bool IsOrgasm
+        {
+            get { return orgasmAnimations.Contains(flags.nowAnimStateName); }
+        }
+
 
         public void Awake()
         {
@@ -77,6 +116,22 @@ namespace KK_ButtPlugin
             StartCoroutine("ScanDevices");
         }
 
+        private string GetPose(int girlIndex = 0)
+        {
+            return flags.nowAnimationInfo.nameAnimation
+                + "." + flags.nowAnimStateName
+                + "." + girlIndex;
+        }
+
+        private float GetPhase(int girlIndex = 0)
+        {
+            if (!animPhases.TryGetValue(GetPose(girlIndex), out float phase))
+            {
+                return 0.0f;  // 
+            }
+            return phase;
+        }
+
         IEnumerator ScanDevices()
         {
             client.StartScan();
@@ -102,22 +157,37 @@ namespace KK_ButtPlugin
         {
             while (!flags.isHSceneEnd)
             {
-                if (flags.nowAnimStateName.Equals("OLoop"))
-                {
-                    DoVibrate(1.0f);
-                }
-                else if (!supportedModes.Contains(flags.mode) || !supportedAnimations.Contains(flags.nowAnimStateName))
+                if (!supportedModes.Contains(flags.mode) || !supportedAnimations.Contains(flags.nowAnimStateName))
                 {
                     // stops vibration when not being lewd
                     DoVibrate(0.0f);
+                    yield return new WaitForSecondsRealtime(1.0f / (float)ButtPlugin.VibrationFrequency.Value);
+                    continue;
                 }
-                else
+
+                var animator = flags.lstHeroine[0].chaCtrl.animBody;
+
+                var speed = flags.speedCalc;
+                var strength = 1.0f;
+                var minVibration = 0.2f;
+
+                // service mode goes into OLoop once male excitement exceeds its threshold
+                if (IsOrgasm)
                 {
-                    // vibrate based on the intensity of the player
-                    // minimum vibration above 0 exists so you always feel something along with the animation
-                    DoVibrate(Mathf.Lerp(0.2f, 1.0f, flags.speedCalc));
+                    speed = 1.0f;
+                    minVibration = 0.6f;
                 }
-                yield return new WaitForSeconds(.01f);
+
+                if (ButtPlugin.SyncVibrationWithAnimation.Value)
+                {
+                    // Simple sin based intensity amplification based on normalized position in looping animation
+                    var info = animator.GetCurrentAnimatorStateInfo(0);
+                    var depth = (info.m_NormalizedTime - GetPhase()) % 1;
+                    strength = Mathf.Sin(Mathf.Lerp(0, Mathf.PI, depth)) + 0.1f;
+                }
+
+                DoVibrate(Mathf.Lerp(minVibration, 1.0f, speed * strength));
+                yield return new WaitForSecondsRealtime(1.0f / (float)ButtPlugin.VibrationFrequency.Value);
             }
             // turn off vibration since there's nothing to animate against
             // this state can happen if H is ended while the animation is not in Idle
@@ -145,10 +215,7 @@ namespace KK_ButtPlugin
                     ? GetSpeedMultiplierFor(0.28f)
                     : GetSpeedMultiplierFor(0.375f);
                 double normTime = info.normalizedTime;
-                string pose = flags.nowAnimationInfo.nameAnimation
-                    + "." + flags.nowAnimStateName
-                    + "." + girlIndex;
-                animPhases.TryGetValue(pose, out float phase);
+                float phase = GetPhase(girlIndex);
                 float strokeTimeSecs = info.length / info.speed;
                 // sometimes info.length becomes Infinity for some reason
                 // this is a catch-all for god knows what other horrors possibly lurking

--- a/KK_ButtPlugin/ButtplugWsClient.cs
+++ b/KK_ButtPlugin/ButtplugWsClient.cs
@@ -1,23 +1,32 @@
 ﻿using LitJson;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using WebSocket4Net;
+using UnityEngine;
 
 namespace KK_ButtPlugin
 {
-    public class ButtplugWsClient
+    public class ButtplugWsClient : MonoBehaviour
     {
         private WebSocket websocket;
-        private readonly Random random = new Random();
+        private readonly System.Random random = new System.Random();
         public List<Device> Devices { get; private set; }
 
         public bool IsConnected { get; private set; }
 
-        public ButtplugWsClient()
+        private void Awake()
         {
             Open();
         }
+
+
+        private void OnDestroy()
+        {
+            Close();
+        }
+        
 
         public void Open()
         {
@@ -125,7 +134,7 @@ namespace KK_ButtPlugin
             websocket.Send(JsonMapper.ToJson(new object[] { deviceListRequest }));
         }
 
-        public void StartScan()
+        private void StartScan()
         {
             var scanRequest = new
             {
@@ -137,7 +146,7 @@ namespace KK_ButtPlugin
             websocket.Send(JsonMapper.ToJson(new object[] { scanRequest }));
         }
 
-        public void StopScan()
+        private void StopScan()
         {
             var scanRequest = new
             {
@@ -147,6 +156,25 @@ namespace KK_ButtPlugin
                 }
             };
             websocket.Send(JsonMapper.ToJson(new object[] { scanRequest }));
+        }
+
+        private IEnumerator ScanDevices()
+        {
+            StartScan();
+            yield return new WaitForSeconds(15.0f);
+            StopScan();
+        }
+
+        public void Scan()
+        {
+            StartCoroutine(ScanDevices());
+        }
+
+        public void Connect()
+        {
+            Close(); // close previous connection just in case
+            Open();
+            Scan();
         }
 
         private void OnMessageReceived(object sender, MessageReceivedEventArgs e)

--- a/KK_ButtPlugin/Hooks.cs
+++ b/KK_ButtPlugin/Hooks.cs
@@ -16,7 +16,9 @@ namespace KK_ButtPlugin
             [HarmonyPatch(typeof(HFlag), nameof(HFlag.Start))]
             public static void Start(HFlag __instance)
             {
-                Chainloader.ManagerObject.GetComponent<ButtplugController>()
+                Chainloader.ManagerObject.GetComponent<ButtplugVibrationController>()
+                    .OnStartH(__instance);
+                Chainloader.ManagerObject.GetComponent<ButtplugStrokerController>()
                     .OnStartH(__instance);
             }
         }


### PR DESCRIPTION
Addresses #17 by adding the a simple sin-wave multiplier based on the normalized animation loop.  Works a lot better than I was expecting, since when it comes to vibrations accuracy is not particularly necessary.  This behavior is toggleable in case the user prefers a more constant simulation tied purely to player controlled animation speed.

Vibration update frequency is also now configurable, preferring a rate of about 30fps, so as not to overwhelm buttplug server or its devices.

![image](https://user-images.githubusercontent.com/316728/126075198-f3e8f308-772a-41a9-a5c7-94d9158985e3.png)



