### PR TITLE
Add Female Vibration Support

### DIFF
--- a/KK_ButtPlugin/ButtPlugin.cs
+++ b/KK_ButtPlugin/ButtPlugin.cs
@@ -18,7 +18,7 @@ namespace KK_ButtPlugin
         public static ConfigEntry<string> WebSocketAddress { get; private set; }
         public static ConfigEntry<int> MaxStrokesPerMinute { get; private set; }
         public static ConfigEntry<int> LatencyMs { get; private set; }
-        public static ConfigEntry<bool> EnableVibrate { get; private set; }
+        public static ConfigEntry<VibrationMode> EnableVibrate { get; private set; }
         public static ConfigEntry<bool> SyncVibrationWithAnimation { get; private set; }
         public static ConfigEntry<int> VibrationUpdateFrequency { get; private set; }
 
@@ -43,7 +43,7 @@ namespace KK_ButtPlugin
             EnableVibrate = Config.Bind(
                 section: "Vibration Settings",
                 key: "Enable Vibrators",
-                defaultValue: true,
+                defaultValue: VibrationMode.Both,
                 "Maps control speed to vibrations"
             );
             SyncVibrationWithAnimation = Config.Bind(
@@ -59,6 +59,7 @@ namespace KK_ButtPlugin
                 defaultValue: 30,
                 "Average times per second we update the vibration state."
             );
+
             Config.Bind(
                 section: "Device List",
                 key: "Connected",


### PR DESCRIPTION
Adds the ability to sync vibrations to female interactions.

Masturbation animations are supported.  They have different levels of intensity depending on the stage of masturbation

Caress actions are not yet supported in this PR.

Female vibration is disabled during service actions for now.  I know kplug has some service actions that do increase the female hgauge, so it might be better in the future to look at that instead of just the hflag mode.