### PR TITLE
Allow defining stroke zone

### DIFF
--- a/ButtPlugin.Core/ButtPluginInitializer.cs
+++ b/ButtPlugin.Core/ButtPluginInitializer.cs
@@ -24,6 +24,24 @@ namespace ButtPlugin.Core
                 key: "Maximum strokes per minute",
                 defaultValue: 140,
                 "The top speed possible on your stroker at 70% stroke length.");
+            CoreConfig.StrokeZoneMin = plugin.Config.Bind(
+                section: "Stroker Settings",
+                key: "Stroke Zone Min",
+                defaultValue: 30,
+                new ConfigDescription(
+                    "Lowest position the stroker will move to.",
+                    new AcceptableValueRange<int>(0, 100)
+                )
+            );
+            CoreConfig.StrokeZoneMax = plugin.Config.Bind(
+                section: "Stroker Settings",
+                key: "Stroke Zone Max",
+                defaultValue: 70,
+                new ConfigDescription(
+                    "Highest position the stroker will move to.",
+                    new AcceptableValueRange<int>(0, 100)
+                )
+            );
             CoreConfig.LatencyMs = plugin.Config.Bind(
                 section: "Stroker Settings",
                 key: "Latency (ms)",

--- a/ButtPlugin.Core/ButtplugController.cs
+++ b/ButtPlugin.Core/ButtplugController.cs
@@ -107,14 +107,17 @@ namespace ButtPlugin.Core
             int strokeTimeMs = (int)(strokeTimeSecs * 1000) - 10;
             // decrease stroke length gradually as speed approaches the device limit
             double rate = 60f / CoreConfig.MaxStrokesPerMinute.Value / strokeTimeSecs;
-            double margin = rate * rate * 0.3;
+            double min = Mathf.InverseLerp(0, 100, CoreConfig.StrokeZoneMin.Value);
+            double max = Mathf.InverseLerp(0, 100, CoreConfig.StrokeZoneMax.Value);
+            double length = max - min;
+            double margin = rate * rate * length;
             client.LinearCmd(
-                position: 1 - margin * 0.7,
+                position: max - margin * (1.0 - length),
                 durationMs: strokeTimeMs / 2,
                 girlIndex);
             yield return new WaitForSeconds(strokeTimeSecs / 2f);
             client.LinearCmd(
-                position: margin * 0.3,
+                position: min + margin * length,
                 durationMs: strokeTimeMs / 2,
                 girlIndex);
         }

--- a/ButtPlugin.Core/CoreConfig.cs
+++ b/ButtPlugin.Core/CoreConfig.cs
@@ -19,6 +19,9 @@ namespace ButtPlugin.Core
         public static ConfigEntry<string> WebSocketAddress { get; internal set; }
         public static ConfigEntry<int> MaxStrokesPerMinute { get; internal set; }
         public static ConfigEntry<int> LatencyMs { get; internal set; }
+        public static ConfigEntry<int> StrokeZoneMin { get; internal set; }
+        public static ConfigEntry<int> StrokeZoneMax { get; internal set; }
+
         public static ConfigEntry<ButtplugController.VibrationMode> EnableVibrate { get; internal set; }
         public static ConfigEntry<bool> SyncVibrationWithAnimation { get; internal set; }
         public static ConfigEntry<int> VibrationUpdateFrequency { get; internal set; }


### PR DESCRIPTION
This attempts to solve #35 by allowing the user to set the minimum and maximum height positions for strokers.

I'm not entirely familiar with the reasoning behind the existing values, however, so if this is not equivalent to the original intent please advise on what should be changed.